### PR TITLE
chore(dev-deps): downgrade `playwright`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/node": "^22.14.0",
     "@vitest/browser": "^3.1.1",
     "eslint": "^9.24.0",
-    "playwright": "^1.51.1",
+    "playwright": "1.49.0",
     "prettier": "^3.5.3",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
         version: 22.14.0
       '@vitest/browser':
         specifier: ^3.1.1
-        version: 3.1.1(playwright@1.51.1)(vite@6.2.6(@types/node@22.14.0))(vitest@3.1.1)(webdriverio@9.12.5)
+        version: 3.1.1(playwright@1.49.0)(vite@6.2.6(@types/node@22.14.0))(vitest@3.1.1)(webdriverio@9.12.5)
       eslint:
         specifier: ^9.24.0
         version: 9.24.0
       playwright:
-        specifier: ^1.51.1
-        version: 1.51.1
+        specifier: 1.49.0
+        version: 1.49.0
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -1693,13 +1693,13 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  playwright-core@1.51.1:
-    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+  playwright-core@1.49.0:
+    resolution: {integrity: sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.51.1:
-    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+  playwright@1.49.0:
+    resolution: {integrity: sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2816,7 +2816,7 @@ snapshots:
       '@typescript-eslint/types': 8.29.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/browser@3.1.1(playwright@1.51.1)(vite@6.2.6(@types/node@22.14.0))(vitest@3.1.1)(webdriverio@9.12.5)':
+  '@vitest/browser@3.1.1(playwright@1.49.0)(vite@6.2.6(@types/node@22.14.0))(vitest@3.1.1)(webdriverio@9.12.5)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
@@ -2828,7 +2828,7 @@ snapshots:
       vitest: 3.1.1(@types/node@22.14.0)(@vitest/browser@3.1.1)
       ws: 8.18.1
     optionalDependencies:
-      playwright: 1.51.1
+      playwright: 1.49.0
       webdriverio: 9.12.5
     transitivePeerDependencies:
       - bufferutil
@@ -4126,11 +4126,11 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  playwright-core@1.51.1: {}
+  playwright-core@1.49.0: {}
 
-  playwright@1.51.1:
+  playwright@1.49.0:
     dependencies:
-      playwright-core: 1.51.1
+      playwright-core: 1.49.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4300,7 +4300,7 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.39.0
       '@rollup/rollup-win32-ia32-msvc': 4.39.0
       '@rollup/rollup-win32-x64-msvc': 4.39.0
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -4686,7 +4686,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.14.0
-      '@vitest/browser': 3.1.1(playwright@1.51.1)(vite@6.2.6(@types/node@22.14.0))(vitest@3.1.1)(webdriverio@9.12.5)
+      '@vitest/browser': 3.1.1(playwright@1.49.0)(vite@6.2.6(@types/node@22.14.0))(vitest@3.1.1)(webdriverio@9.12.5)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
- Downgrade `playwright` to avoid https://github.com/vitest-dev/vitest/issues/7377

See https://github.com/stackblitz/webcontainer-test/actions/runs/14488808706/job/40641216025

```
⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: Failed to connect to the browser session "243e2a75-c500-403e-83c9-66b04a7f1164" [Firefox] for "test/mount.test.ts", "test/file-system.test.ts" within the timeout.
 ❯ Timeout._onTimeout node_modules/.pnpm/vitest@3.1.1_@types+node@22.14.0_@vitest+browser@3.1.1/node_modules/vitest/dist/chunks/cli-api.bwYuoT4p.js:5263:17
 ❯ listOnTimeout node:internal/timers:594:17
 ❯ process.processTimers node:internal/timers:529:7
```
