### PR TITLE
feat: add `setup()` caching fixture

### DIFF
--- a/src/fixtures/file-system.ts
+++ b/src/fixtures/file-system.ts
@@ -67,4 +67,14 @@ export class FileSystem {
   async rm(path: string) {
     return this._instance.fs.rm(path);
   }
+
+  /** @internal */
+  async export() {
+    return await this._instance.export("./", { format: "binary" });
+  }
+
+  /** @internal */
+  async restore(snapshot: Uint8Array) {
+    return await this._instance.mount(new Uint8Array(snapshot));
+  }
 }

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, expect } from "vitest";
+import { test, type TestContext } from "../src";
+
+const counts = { setup: 0, beforeEach: 0 };
+
+beforeEach<TestContext>(async ({ setup, webcontainer }) => {
+  await setup(async () => {
+    await webcontainer.writeFile("./example", "Hello world");
+    counts.setup++;
+  });
+
+  counts.beforeEach++;
+});
+
+test.for([1, 2, 3])("state is restored %d", async (count, { webcontainer }) => {
+  await expect(webcontainer.readFile("example")).resolves.toBe("Hello world");
+
+  // setup should always be called just once as it's cached
+  expect(counts.setup).toBe(1);
+
+  // hook itself is called each time
+  expect(counts.beforeEach).toBe(count);
+});


### PR DESCRIPTION
- Let's see if this could be used to speed up repetitive `mount();  runCommand("npm install")` steps