### PR TITLE
fix!: rename plugin to `vitestWebContainers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ $ npm install --save-dev vitest @vitest/browser
 
 ## Configuration
 
-Add `vitestWebcontainers` plugin in your Vitest config and enable browser mode:
+Add `vitestWebContainers` plugin in your Vitest config and enable browser mode:
 
 ```ts
 import { defineConfig } from "vitest/config";
-import { vitestWebcontainers } from "@webcontainer/test/plugin";
+import { vitestWebContainers } from "@webcontainer/test/plugin";
 
 export default defineConfig({
-  plugins: [vitestWebcontainers()],
+  plugins: [vitestWebContainers()],
   test: {
     browser: {
       enabled: true,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,7 +8,7 @@ const COOP = "Cross-Origin-Opener-Policy";
  * Vitest [plugin](https://vitest.dev/advanced/api/plugin.html#plugin-api) for configuring
  * WebContainer related options.
  */
-export function vitestWebcontainers(): Vite.Plugin {
+export function vitestWebContainers(): Vite.Plugin {
   return {
     name: "vitest:webcontainers",
     config(config, env) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from "vitest/config";
-import { vitestWebcontainers } from "./src/plugin";
+import { vitestWebContainers } from "./src/plugin";
 
 export default defineConfig({
-  plugins: [vitestWebcontainers()],
+  plugins: [vitestWebContainers()],
 
   test: {
     reporters: "verbose",


### PR DESCRIPTION
- Renames `vitestWebcontainers` to `vitestWebContainers`.

Migration:

```diff
- import { vitestWebcontainers } from "@webcontainer/test/plugin";
+ import { vitestWebContainers } from "@webcontainer/test/plugin";
```